### PR TITLE
Update raml-path-selector.html

### DIFF
--- a/raml-path-selector.html
+++ b/raml-path-selector.html
@@ -175,11 +175,8 @@ See other elemets documentation more styling options.
     <style>
     :host {
       display: block;
-
-      background-color: var(--raml-path-selector-background-color, --primary-background-color);
       background: transparent;
       color: var(--raml-path-selector-color, --primary-text-color);
-
       overflow: auto;
       @apply(--raml-path-selector);
     }

--- a/raml-path-selector.html
+++ b/raml-path-selector.html
@@ -177,6 +177,7 @@ See other elemets documentation more styling options.
       display: block;
 
       background-color: var(--raml-path-selector-background-color, --primary-background-color);
+      background: transparent;
       color: var(--raml-path-selector-color, --primary-text-color);
 
       overflow: auto;

--- a/raml-path-selector.html
+++ b/raml-path-selector.html
@@ -175,7 +175,7 @@ See other elemets documentation more styling options.
     <style>
     :host {
       display: block;
-      background: transparent;
+      background-color: var(--raml-path-selector-background-color, var(--primary-background-color, transparent));
       color: var(--raml-path-selector-color, --primary-text-color);
       overflow: auto;
       @apply(--raml-path-selector);


### PR DESCRIPTION
There was a second between the component load and `api-console-styles` are applied to it. So the background for a second becomes white until styles are loaded.

I've updated the background for `raml-path-selector` just to be transparent, no mixins.